### PR TITLE
feat: system call implementation for Berachain integration

### DIFF
--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -1,8 +1,7 @@
 //! Ethereum EVM implementation.
 
 use crate::{env::EvmEnv, evm::EvmFactory, precompiles::PrecompilesMap, Database, Evm};
-use alloc::vec::Vec;
-use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_primitives::{Address, Bytes};
 use core::{
     fmt::Debug,
     ops::{Deref, DerefMut},
@@ -15,7 +14,7 @@ use revm::{
     interpreter::{interpreter::EthInterpreter, InterpreterResult},
     precompile::{PrecompileSpecId, Precompiles},
     primitives::hardfork::SpecId,
-    Context, ExecuteEvm, InspectEvm, Inspector, MainBuilder, MainContext,
+    Context, ExecuteEvm, InspectEvm, Inspector, MainBuilder, MainContext, SystemCallEvm,
 };
 
 mod block;
@@ -143,61 +142,7 @@ where
         contract: Address,
         data: Bytes,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        let tx = TxEnv {
-            caller,
-            kind: TxKind::Call(contract),
-            // Explicitly set nonce to 0 so revm does not do any nonce checks
-            nonce: 0,
-            gas_limit: 30_000_000,
-            value: U256::ZERO,
-            data,
-            // Setting the gas price to zero enforces that no value is transferred as part of the
-            // call, and that the call will not count against the block's gas limit
-            gas_price: 0,
-            // The chain ID check is not relevant here and is disabled if set to None
-            chain_id: None,
-            // Setting the gas priority fee to None ensures the effective gas price is derived from
-            // the `gas_price` field, which we need to be zero
-            gas_priority_fee: None,
-            access_list: Default::default(),
-            // blob fields can be None for this tx
-            blob_hashes: Vec::new(),
-            max_fee_per_blob_gas: 0,
-            tx_type: 0,
-            authorization_list: Default::default(),
-        };
-
-        let mut gas_limit = tx.gas_limit;
-        let mut basefee = 0;
-        let mut disable_nonce_check = true;
-
-        // ensure the block gas limit is >= the tx
-        core::mem::swap(&mut self.block.gas_limit, &mut gas_limit);
-        // disable the base fee check for this call by setting the base fee to zero
-        core::mem::swap(&mut self.block.basefee, &mut basefee);
-        // disable the nonce check
-        core::mem::swap(&mut self.cfg.disable_nonce_check, &mut disable_nonce_check);
-
-        let mut res = self.transact(tx);
-
-        // swap back to the previous gas limit
-        core::mem::swap(&mut self.block.gas_limit, &mut gas_limit);
-        // swap back to the previous base fee
-        core::mem::swap(&mut self.block.basefee, &mut basefee);
-        // swap back to the previous nonce check flag
-        core::mem::swap(&mut self.cfg.disable_nonce_check, &mut disable_nonce_check);
-
-        // NOTE: We assume that only the contract storage is modified. Revm currently marks the
-        // caller and block beneficiary accounts as "touched" when we do the above transact calls,
-        // and includes them in the result.
-        //
-        // We're doing this state cleanup to make sure that changeset only includes the changed
-        // contract storage.
-        if let Ok(res) = &mut res {
-            res.state.retain(|addr, _| *addr == contract);
-        }
-
-        res
+        self.inner.transact_system_call_with_caller_finalize(caller, contract, data)
     }
 
     fn db_mut(&mut self) -> &mut Self::DB {

--- a/crates/op-evm/src/lib.rs
+++ b/crates/op-evm/src/lib.rs
@@ -9,14 +9,12 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
 use alloy_evm::{precompiles::PrecompilesMap, Database, Evm, EvmEnv, EvmFactory};
-use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_primitives::{Address, Bytes};
 use core::{
     fmt::Debug,
     ops::{Deref, DerefMut},
 };
-use op_alloy_consensus::OpTxType;
 use op_revm::{
     precompiles::OpPrecompiles, DefaultOp, OpBuilder, OpContext, OpHaltReason, OpSpecId,
     OpTransaction, OpTransactionError,
@@ -27,7 +25,7 @@ use revm::{
     handler::{instructions::EthInstructions, PrecompileProvider},
     inspector::NoOpInspector,
     interpreter::{interpreter::EthInterpreter, InterpreterResult},
-    Context, ExecuteEvm, InspectEvm, Inspector,
+    Context, ExecuteEvm, InspectEvm, Inspector, SystemCallEvm,
 };
 
 pub mod block;
@@ -124,68 +122,7 @@ where
         contract: Address,
         data: Bytes,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        let tx = OpTransaction {
-            base: TxEnv {
-                caller,
-                kind: TxKind::Call(contract),
-                // Explicitly set nonce to 0 so revm does not do any nonce checks
-                nonce: 0,
-                gas_limit: 30_000_000,
-                value: U256::ZERO,
-                data,
-                // Setting the gas price to zero enforces that no value is transferred as part of
-                // the call, and that the call will not count against the block's
-                // gas limit
-                gas_price: 0,
-                // The chain ID check is not relevant here and is disabled if set to None
-                chain_id: None,
-                // Setting the gas priority fee to None ensures the effective gas price is derived
-                // from the `gas_price` field, which we need to be zero
-                gas_priority_fee: None,
-                access_list: Default::default(),
-                // blob fields can be None for this tx
-                blob_hashes: Vec::new(),
-                max_fee_per_blob_gas: 0,
-                tx_type: OpTxType::Deposit as u8,
-                authorization_list: Default::default(),
-            },
-            // The L1 fee is not charged for the EIP-4788 transaction, submit zero bytes for the
-            // enveloped tx size.
-            enveloped_tx: Some(Bytes::default()),
-            deposit: Default::default(),
-        };
-
-        let mut gas_limit = tx.base.gas_limit;
-        let mut basefee = 0;
-        let mut disable_nonce_check = true;
-
-        // ensure the block gas limit is >= the tx
-        core::mem::swap(&mut self.block.gas_limit, &mut gas_limit);
-        // disable the base fee check for this call by setting the base fee to zero
-        core::mem::swap(&mut self.block.basefee, &mut basefee);
-        // disable the nonce check
-        core::mem::swap(&mut self.cfg.disable_nonce_check, &mut disable_nonce_check);
-
-        let mut res = self.transact(tx);
-
-        // swap back to the previous gas limit
-        core::mem::swap(&mut self.block.gas_limit, &mut gas_limit);
-        // swap back to the previous base fee
-        core::mem::swap(&mut self.block.basefee, &mut basefee);
-        // swap back to the previous nonce check flag
-        core::mem::swap(&mut self.cfg.disable_nonce_check, &mut disable_nonce_check);
-
-        // NOTE: We assume that only the contract storage is modified. Revm currently marks the
-        // caller and block beneficiary accounts as "touched" when we do the above transact calls,
-        // and includes them in the result.
-        //
-        // We're doing this state cleanup to make sure that changeset only includes the changed
-        // contract storage.
-        if let Ok(res) = &mut res {
-            res.state.retain(|addr, _| *addr == contract);
-        }
-
-        res
+        self.inner.transact_system_call_with_caller_finalize(caller, contract, data)
     }
 
     fn db_mut(&mut self) -> &mut Self::DB {


### PR DESCRIPTION
## Summary
**Temporary fork** of alloy-evm to support Berachain integration while waiting for upstream updates.

- Implements system call functionality using revm's system_call method
- Updates to alloy-evm 0.14.0 with enhanced system call support  
- Enables proper integration with Berachain's execution client requirements

## Temporary Nature
This fork is **temporary** and will be removed once:
- [ ] A new alloy-evm release is published with the required system call functionality
- [ ] Reth upstream is updated to use the new alloy-evm release
- [ ] Berachain can migrate back to using official alloy-evm releases

## Changes
- Added system call implementation using revm's native system_call method
- Updated dependencies to support enhanced system call functionality
- Maintains compatibility with existing alloy-evm interfaces

## Test Plan
- [x] Local integration testing with bera-reth
- [x] System call functionality verified
- [ ] Full integration test suite with BeaconKit

## Migration Path
Once upstream releases are available:
1. Remove this fork from bera-reth dependencies
2. Update to official alloy-evm release
3. Archive this temporary repository

This PR enables bera-reth to properly handle system calls required for Berachain's execution layer until official upstream support is available.